### PR TITLE
Tmp fix for loading jars

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,3 @@ This repository consists of data pipelines using yaetos data framework ([github.
 
 Lots of room for improvements. Contributions welcome. Feel free to reach out at arthur@yaetos.com. 
 
-#----- TODO: to add later ------
- * Data pipeline to process banking information, grouping data from various accounts, re-labeling transactions differently from the bank, and organising it in a way not available from the bank.
- * Data pipeline to pull all contacts from various sources and put it in one dataset.
-

--- a/conf/jobs_metadata.yml
+++ b/conf/jobs_metadata.yml
@@ -477,7 +477,7 @@ common_params:
       aws_config_file:  conf/aws_config.cfg
       aws_setup:        pro
       jobs_folder:      jobs/
-      load_connectors: all
+      load_connectors: none
       enable_db_push: True
       save_schemas: False
       manage_git_info: True
@@ -488,7 +488,7 @@ common_params:
       aws_config_file:  conf/aws_config.cfg
       aws_setup:        dev
       jobs_folder:      jobs/
-      load_connectors: all
+      load_connectors: none
       enable_db_push: False
       save_schemas: False
       manage_git_info: True


### PR DESCRIPTION
set load_connector to not load jars, caused pb for last runs in EMR (error message with missing ivy). Need to be better debug or removed. since load_connector=all doesn't work right now on EMR (some jobs still use it after this change)

```
:: loading settings :: url = jar:file:/usr/lib/spark/jars/ivy-2.5.1.jar!/org/apache/ivy/core/settings/ivysettings.xml
```